### PR TITLE
Makefile and script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all clean package release run
 
+export SHELL := /bin/bash
+
 NW := $(shell which nw)
 
 allcss = $(shell find ../js/css/ -name "*.css" \

--- a/scripts/do-release
+++ b/scripts/do-release
@@ -6,7 +6,7 @@ VERSION=$2
 YEAR=$(date +'%Y')
 
 APP=`realpath .`
-RELEASE="$(realpath ${APP}/release/nwjs/${PLATFORM})"
+RELEASE=${APP}/release/nwjs/${PLATFORM}
 RELEASE_DIR=${APP}/release
 TMP=${RELEASE}/../tmp
 

--- a/scripts/do-release
+++ b/scripts/do-release
@@ -17,8 +17,8 @@ if [ "${PLATFORM}" == "" ]; then
 fi
 
 if [ ! -d ${RELEASE} ]; then
-	echo "Error: ${RELEASE} not present"
-	exit 1
+        echo "Creating ${RELEASE}..."
+        mkdir -p ${RELEASE}
 fi
 
 pushd ${RELEASE} > /dev/null || {

--- a/scripts/do-release
+++ b/scripts/do-release
@@ -40,6 +40,7 @@ if [ "${PLATFORM}" == "linux32" ] || [ "${PLATFORM}" == "linux64" ]; then
 	pushd ${TMP}
 	cp ${RELEASE_DIR}/package.nw ${SUBDIR}
 	mv ${SUBDIR}/nw ${SUBDIR}/turtl-bin
+	chmod 755 ${SUBDIR}/turtl-bin
 
 	cp ${APP}/scripts/resources/favicon.128.png ${SUBDIR}/icon.png
 	cp ${APP}/scripts/resources/turtl-linux-init.sh ${SUBDIR}/turtl


### PR DESCRIPTION
This patch set helps with three things: Building on Ubuntu, packaging on Ubuntu, and rootless execution of Turtl on Ubuntu.