### PR TITLE
Allow non-root installation to a relative path

### DIFF
--- a/scripts/installers/linux
+++ b/scripts/installers/linux
@@ -29,7 +29,7 @@ LOCAL_SHARE=~/.local/share
 ROOT=${GLOBAL_PATH}
 SHARE=${GLOBAL_SHARE}
 if [ "${LOCATION}" != "uninstall" ] && [ "${LOCATION}" != "" ]; then
-	LOCAL_PATH=${LOCATION}
+        LOCAL_PATH=$(readlink -f ${LOCATION})
 	if [ "$(readlink -e ${LOCAL_PATH})" == "$(readlink -e ~)" ]; then
 		LOCAL_PATH=~/turtl
 	fi


### PR DESCRIPTION
Tried to install as non-root user to a relative path. This resulted in installation relative to install.sh rather than where I wanted it. This change converts a relative path to absolute prior to installing.
Please check my indenting (tab vs spaces) for the changed line. It looks incorrect.
